### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 title = "Rust Augsburg Meetup"
 #authors = ["Tiago Manczak", "Michael Schury"]
-multilingual = false
 src = "src"
 language = "en"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10